### PR TITLE
php-gd php-xml php-mbstring

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -38,7 +38,7 @@ sudo apt-get install mysql-server-5.5 mysql-client phpmyadmin --assume-yes --for
 
 echo "--- Instalando PHP, Apache e alguns modulos ---"
 sudo apt-get install php7.1 php7.1-common --assume-yes --force-yes
-sudo apt-get install php7.1-cli libapache2-mod-php7.1 php7.1-mysql php7.1-curl php-memcached php7.1-dev php7.1-mcrypt php7.1-sqlite3 php7.1-mbstring php-gd php-xml php-mbstring  zip unzip --assume-yes --force-yes
+sudo apt-get install php7.1-cli libapache2-mod-php7.1 php7.1-mysql php7.1-curl php-memcached php7.1-dev php7.1-mcrypt php7.1-sqlite3 php7.1-mbstring php*-mysql  php-gd php-xml php-mbstring  zip unzip --assume-yes --force-yes
 
 echo "--- Habilitando o PHP 7.1 ---"
 sudo a2dismod php5

--- a/setup.sh
+++ b/setup.sh
@@ -38,7 +38,7 @@ sudo apt-get install mysql-server-5.5 mysql-client phpmyadmin --assume-yes --for
 
 echo "--- Instalando PHP, Apache e alguns modulos ---"
 sudo apt-get install php7.1 php7.1-common --assume-yes --force-yes
-sudo apt-get install php7.1-cli libapache2-mod-php7.1 php7.1-mysql php7.1-curl php-memcached php7.1-dev php7.1-mcrypt php7.1-sqlite3 php7.1-mbstring zip unzip --assume-yes --force-yes
+sudo apt-get install php7.1-cli libapache2-mod-php7.1 php7.1-mysql php7.1-curl php-memcached php7.1-dev php7.1-mcrypt php7.1-sqlite3 php7.1-mbstring php-gd php-xml php-mbstring  zip unzip --assume-yes --force-yes
 
 echo "--- Habilitando o PHP 7.1 ---"
 sudo a2dismod php5


### PR DESCRIPTION
**Ao instalar e tentar criar um projeto no Laravel ele dava o seguinte erro:** 
 Problem 1
- laravel/framework v5.2.9 requires ext-mbstring * -> the requested PHP extension mbstring is missing from your system.
- laravel/framework v5.2.8 requires ext-mbstring * -> the requested PHP extension mbstring is missing from your system.
- laravel/framework v5.2.7 requires ext-mbstring * -> the requested PHP extension mbstring is missing from your system.
- laravel/framework v5.2.6 requires ext-mbstring * -> the requested PHP extension mbstring is missing from your system.
- laravel/framework v5.2.5 requires ext-mbstring * -> the requested PHP extension mbstring is missing from your system.
- laravel/framework v5.2.4 requires ext-mbstring * -> the requested PHP extension mbstring is missing from your system.
- laravel/framework v5.2.31 requires ext-mbstring * -> the requested PHP extension mbstring is missing from your system.
- laravel/framework v5.2.30 requires ext-mbstring * -> the requested PHP extension mbstring is missing from your system.
- laravel/framework v5.2.3 requires ext-mbstring * -> the requested PHP extension mbstring is missing from your system.
- laravel/framework v5.2.29 requires ext-mbstring * -> the requested PHP extension mbstring is missing from your system.
- laravel/framework v5.2.28 requires ext-mbstring * -> the requested PHP extension mbstring is missing from your system.
- laravel/framework v5.2.27 requires ext-mbstring * -> the requested PHP extension mbstring is missing from your system.
- laravel/framework v5.2.26 requires ext-mbstring * -> the requested PHP extension mbstring is missing from your system.
- laravel/framework v5.2.25 requires ext-mbstring * -> the requested PHP extension mbstring is missing from your system.
- laravel/framework v5.2.24 requires ext-mbstring * -> the requested PHP extension mbstring is missing from your system.
- laravel/framework v5.2.23 requires ext-mbstring * -> the requested PHP extension mbstring is missing from your system.
- laravel/framework v5.2.22 requires ext-mbstring * -> the requested PHP extension mbstring is missing from your system.
- laravel/framework v5.2.21 requires ext-mbstring * -> the requested PHP extension mbstring is missing from your system.
- laravel/framework v5.2.20 requires ext-mbstring * -> the requested PHP extension mbstring is missing from your system.
- laravel/framework v5.2.2 requires ext-mbstring * -> the requested PHP extension mbstring is missing from your system.
- laravel/framework v5.2.19 requires ext-mbstring * -> the requested PHP extension mbstring is missing from your system.
- laravel/framework v5.2.18 requires ext-mbstring * -> the requested PHP extension mbstring is missing from your system.
- laravel/framework v5.2.17 requires ext-mbstring * -> the requested PHP extension mbstring is missing from your system.
- laravel/framework v5.2.16 requires ext-mbstring * -> the requested PHP extension mbstring is missing from your system.
- laravel/framework v5.2.15 requires ext-mbstring * -> the requested PHP extension mbstring is missing from your system.
- laravel/framework v5.2.14 requires ext-mbstring * -> the requested PHP extension mbstring is missing from your system.
- laravel/framework v5.2.13 requires ext-mbstring * -> the requested PHP extension mbstring is missing from your system.
- laravel/framework v5.2.12 requires ext-mbstring * -> the requested PHP extension mbstring is missing from your system.
- laravel/framework v5.2.11 requires ext-mbstring * -> the requested PHP extension mbstring is missing from your system.
- laravel/framework v5.2.10 requires ext-mbstring * -> the requested PHP extension mbstring is missing from your system.
- laravel/framework v5.2.1 requires ext-mbstring * -> the requested PHP extension mbstring is missing from your system.
- laravel/framework v5.2.0 requires ext-mbstring * -> the requested PHP extension mbstring is missing from your system.
- laravel/framework v5.2.30 requires ext-mbstring * -> the requested PHP extension mbstring is missing from your system.
- Installation request for laravel/framework 5.2.* -> satisfiable by laravel/framework[v5.2.0, v5.2.1, v5.2.10, v5.2.11, v5.2.12, v5.2.13, v5.2.14, v5.2.15, v5.2.16, v5.2.17, v5.2.18, v5.2.19, v5.2.2, v5.2.20, v5.2.21, v5.2.22, v5.2.23, v5.2.24, v5.2.25, v5.2.26, v5.2.27, v5.2.28, v5.2.29, v5.2.3, v5.2.30, v5.2.31, v5.2.4, v5.2.5, v5.2.6, v5.2.7, v5.2.8, v5.2.9].

To enable extensions, verify that they are enabled in those .ini files:
- /etc/php/7.0/cli/php.ini
- /etc/php/7.0/cli/conf.d/10-mysqlnd.ini
- /etc/php/7.0/cli/conf.d/10-opcache.ini
- /etc/php/7.0/cli/conf.d/10-pdo.ini
- /etc/php/7.0/cli/conf.d/20-calendar.ini
- /etc/php/7.0/cli/conf.d/20-ctype.ini
- /etc/php/7.0/cli/conf.d/20-exif.ini
- /etc/php/7.0/cli/conf.d/20-fileinfo.ini
- /etc/php/7.0/cli/conf.d/20-ftp.ini
- /etc/php/7.0/cli/conf.d/20-gettext.ini
- /etc/php/7.0/cli/conf.d/20-iconv.ini
- /etc/php/7.0/cli/conf.d/20-json.ini
- /etc/php/7.0/cli/conf.d/20-mysqli.ini
- /etc/php/7.0/cli/conf.d/20-pdo_mysql.ini
- /etc/php/7.0/cli/conf.d/20-phar.ini
- /etc/php/7.0/cli/conf.d/20-posix.ini
- /etc/php/7.0/cli/conf.d/20-readline.ini
- /etc/php/7.0/cli/conf.d/20-shmop.ini
- /etc/php/7.0/cli/conf.d/20-sockets.ini
- /etc/php/7.0/cli/conf.d/20-sysvmsg.ini
- /etc/php/7.0/cli/conf.d/20-sysvsem.ini
- /etc/php/7.0/cli/conf.d/20-sysvshm.ini
- /etc/php/7.0/cli/conf.d/20-tokenizer.ini
You can also run `php --ini` inside terminal to see which files are used by PHP in CLI mode.

Instalando essas extensões do PHP o problema é resolvido.